### PR TITLE
Fix broken content_type

### DIFF
--- a/lib/Bailador/App.pm
+++ b/lib/Bailador/App.pm
@@ -31,10 +31,10 @@ class Bailador::App does Bailador::Routing {
         }
     }
 
-    multi method render(Int :$status = 200, Str :$type = 'text/html', :$content!) {
+    multi method render(Int :$status = 200, Str :$type, :$content!) {
         $.context.autorender = False;
         self.response.code = $status;
-        self.response.headers<Content-Type> = $type;
+        self.response.headers<Content-Type> = $type if $type;
         self.response.content = $content;
     }
 


### PR DESCRIPTION
Currently, setting `content_type` is ignored. This change fixes it. There's no need to set `text/html` as default in `render` method because it's set to that value elsewhere.