### PR TITLE
Improve example

### DIFF
--- a/examples/app.pl6
+++ b/examples/app.pl6
@@ -23,13 +23,8 @@ get /foo(.+)/ => sub ($x) {
     "regexes! I got $x"
 }
 
-get / '/' (.+) '-' (.+)/ => sub ($x, $y) {
+get rx{ '/' (.+) '-' (.+) } => sub ($x, $y) {
     "$x and $y"
-}
-
-# junctions work too
-get any('/h', '/help', '/halp') => sub {
-    "junctions are cool"
 }
 
 # templates!


### PR DESCRIPTION
Get rid of unimplemented junctions. Show an alternate way to write a regex route without using the `/` regex delimiters that clash with path separator.

Closes #72 