### PR TITLE
Proposition for a 'prefix' command

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -20,6 +20,14 @@ our sub import {
     app.location = callframe(1).file.IO.dirname;
 }
 
+sub prefix(Str $p) is export {
+    app.prefix: $p;
+}
+
+sub noprefix is export {
+    app.noprefix;
+}
+
 sub get(Pair $x) is export {
     app.add_route: 'GET', $x;
     return $x;

--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -20,8 +20,14 @@ our sub import {
     app.location = callframe(1).file.IO.dirname;
 }
 
-sub prefix(Str $p) is export {
+multi sub prefix(Str $p) is export {
     app.prefix: $p;
+}
+
+multi sub prefix( Str $p, Code $c ) {
+    app.prefix: $p;
+    $c();
+    noprefix;
 }
 
 sub noprefix is export {

--- a/lib/Bailador/Route.pm
+++ b/lib/Bailador/Route.pm
@@ -7,6 +7,7 @@ class Bailador::Route { ... }
 
 role Bailador::Routing {
     has Bailador::Route @.routes;
+    has Str $!prefix;
 
     method recurse-on-routes(Str $method, Str $uri) {
 
@@ -45,8 +46,23 @@ role Bailador::Routing {
     }
 
     multi method add_route(Str $method, Pair $x) {
-        my $route = Bailador::Route.new($method, $x);
+        my $path;
+        if $!prefix {
+            $path = $!prefix ~ $x.key;
+        } else {
+            $path = $x.key;
+        }
+
+        my $route = Bailador::Route.new($method, $path, $x.value);
         @.routes.push($route);
+    }
+
+    multi method prefix(Str $new-prefix) {
+        $!prefix = $new-prefix;
+    }
+
+    multi method noprefix {
+        $!prefix = '';
     }
 
     ## syntactic sugar!


### PR DESCRIPTION
Add the possibility to add a prefix to a route.
```perl6
prefix '/pref';
get '/abc' => sub { 'abc' }; # Will match '/pref/abc'
noprefix;
prefix '/b', {
  get '/abc' => sub { 'abc' }; # Will match '/b/abc'
}
```
Does not work with Route object (should it? ).