### PR TITLE
support non-OO custom rootdir via ::import()

### DIFF
--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -113,5 +113,3 @@ sub baile($port = 3000) is export {
         .run;
     }
 }
-
-# vim: filetype=perl6

--- a/lib/Bailador.pm
+++ b/lib/Bailador.pm
@@ -17,8 +17,8 @@ multi sub app(Bailador::App $myapp) is export {
     $app = $myapp;
 }
 
-our sub import {
-    app.location = callframe(1).file.IO.dirname;
+our sub import(Str :$rootdir) {
+    app.location = $rootdir || callframe(1).file.IO.dirname;
 }
 
 sub get(Pair $x) is export {
@@ -113,3 +113,5 @@ sub baile($port = 3000) is export {
         .run;
     }
 }
+
+# vim: filetype=perl6

--- a/lib/Bailador/App.pm
+++ b/lib/Bailador/App.pm
@@ -139,5 +139,3 @@ class Bailador::App is Bailador::Route {
         return self.^method_table{$method}.assuming(self, |@args);
     }
 }
-
-# vim: filetype=perl6

--- a/lib/Bailador/App.pm
+++ b/lib/Bailador/App.pm
@@ -139,3 +139,5 @@ class Bailador::App is Bailador::Route {
         return self.^method_table{$method}.assuming(self, |@args);
     }
 }
+
+# vim: filetype=perl6


### PR DESCRIPTION
This is to support custom rootdir for non-OO use:

```perl6
use Bailador;
Bailador::import(rootdir => "/path/to/app/");

get '/' => sub {
  template 'index.tt', { name => "Bailador" }
}
```

That would allow for loading templates from `/path/to/app/views`. It is optional and ignored when calling `Bailador::import;`

Sam