### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -5,6 +5,7 @@
     "description" : "A bare-bones Dancer port",
     "depends"     : [ "HTTP::Easy", "Template::Mojo", "Template::Mustache", "URI", "Digest::HMAC", "Digest", "HTTP::MultiPartParser" ],
     "tags"        : [ "Web", "HTTP", "Net" ],
+    "license"     : "MIT",
     "provides" : {
         "Bailador"                                : "lib/Bailador.pm",
         "Bailador::App"                           : "lib/Bailador/App.pm",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license