### PR TITLE
Fix assumptions about internals of IO::Handle

### DIFF
--- a/lib/Bailador/Test.pm
+++ b/lib/Bailador/Test.pm
@@ -7,12 +7,19 @@ unit module Bailador::Test;
 
 # It would be nice to have IO::String here instead
 my class IO::Null is IO::Handle {
-    method print(*@what) {
-        diag @what;
+    multi method print(Str:D \string ) { diag string }
+    multi method print(**@args is raw) { diag join '', @args.map: *.Str }
+
+    method print-nl { diag $.nl-out }
+
+    multi method put(Str:D \string)  { diag string ~ $.nl-out }
+    multi method put(**@args is raw) {
+        diag join '', @args.map(*.Str), $.nl-out
     }
 
-    method print-nl(*@what) {
-        diag @what;
+    multi method say(Str:D \string)  { diag string ~ $.nl-out }
+    multi method say(**@args is raw) {
+        diag join '', @args.map(*.gist), $.nl-out
     }
 }
 


### PR DESCRIPTION
- Fixes test failures on latest Rakudos
- Do not assume .say is implemented in terms of .print
- Do not assume &diag takes any old junk
- Add proper impl of put/print/print-nl/say

I don't know to what extent Bailador::Test is used, but perhaps a more robust impl of custom IO::Handle is needed (or as the comment mentions, use IO::String)